### PR TITLE
 Use `key` instead of `props.episode.title` when setting podcast list…

### DIFF
--- a/components/episode.js
+++ b/components/episode.js
@@ -46,13 +46,10 @@ export default function Episode(props) {
         const newListenTimes = new Map(props.listenTimes);
 
         if (finished) {
-            await props.state.session.setPodcastListenTime(
-                props.episode.title,
-                0
-            );
+            await props.state.session.setPodcastListenTime(key, 0);
             newListenTimes.set(key, [0, false]);
         } else {
-            await props.state.session.setPodcastFinished(props.episode.title);
+            await props.state.session.setPodcastFinished(key);
             newListenTimes.set(key, [0, true]);
         }
         props.state.setListenTimes(newListenTimes);


### PR DESCRIPTION
…en time and finished status.